### PR TITLE
Fix the issue with Babel 6 causing `regeneratorRuntime is undefined

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["env", "react"]
+  "presets": ["env", "react"],
+  "plugins": [
+    ["transform-runtime", {
+      "polyfill": false,
+      "regenerator": true
+    }]
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2563,6 +2563,15 @@
         "regenerator-transform": "^0.10.0"
       }
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -12426,12 +12435,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "babel-jest": "23.6.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-react": "6.24.1",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "codecov": "3.1.0",
     "husky": "1.0.1",
     "jest": "23.6.0",
@@ -46,7 +48,6 @@
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "react-testing-library": "5.1.0",
-    "regenerator-runtime": "0.12.1",
     "semantic-release": "^15.9.16",
     "travis-deploy-once": "5.0.9"
   },


### PR DESCRIPTION
I updated the `user-event`-package in my work project and I was getting `regeneratorRuntime is undefined` errors while running unit tests that import this package.

I think the PR should fix the problem it appears to do for me.