### PR TITLE
Disabled checkboxes should ignore clicks.

### DIFF
--- a/__tests__/click.js
+++ b/__tests__/click.js
@@ -191,6 +191,15 @@ describe("userEvent.click", () => {
     expect(getByTestId("input")).toHaveProperty("checked", true);
   });
 
+  it('should not check a disabled <input type="checkbox">', () => {
+    const { getByTestId } = render(
+      <input id="input" data-testid="input" type="checkbox" disabled />
+    );
+    expect(getByTestId("input")).toHaveProperty("checked", false);
+    userEvent.click(getByTestId("input"));
+    expect(getByTestId("input")).toHaveProperty("checked", false);
+  });
+
   it("should submit a form when clicking on a <button>", () => {
     const onSubmit = jest.fn();
     const { getByText } = render(

--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,9 @@ const userEvent = {
         break;
       case "INPUT":
         if (element.type === "checkbox") {
-          clickCheckbox(element);
+          if (!element.disabled) {
+            clickCheckbox(element);
+          }
           break;
         }
       default:


### PR DESCRIPTION
I noticed that a `disabled` checkbox would still allow `click` to work which does not feel right (it is not how `button` or other elements behave.) Here is a small PR to address this.