### PR TITLE
fix: 🐛 don't fire events when clicking disabled checkbox

### DIFF
--- a/__tests__/click.js
+++ b/__tests__/click.js
@@ -67,6 +67,31 @@ describe("userEvent.click", () => {
     expect(getByTestId("element")).toHaveProperty("checked", true);
   });
 
+  it('should fire the correct events for <input type="checkbox" disabled>', () => {
+    const events = [];
+    const eventsHandler = jest.fn(evt => events.push(evt.type));
+    const { getByTestId } = render(
+      <input
+        data-testid="element"
+        type="checkbox"
+        onMouseOver={eventsHandler}
+        onMouseMove={eventsHandler}
+        onMouseDown={eventsHandler}
+        onFocus={eventsHandler}
+        onMouseUp={eventsHandler}
+        onClick={eventsHandler}
+        onChange={eventsHandler}
+        disabled
+      />
+    );
+
+    userEvent.click(getByTestId("element"));
+
+    expect(events).toEqual([]);
+
+    expect(getByTestId("element")).toHaveProperty("checked", true);
+  });
+
   it("should fire the correct events for <div>", () => {
     const events = [];
     const eventsHandler = jest.fn(evt => events.push(evt.type));

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,10 @@ function clickLabel(label) {
 }
 
 function clickCheckbox(checkbox) {
+  if (checkbox.disabled) {
+    return;
+  }
+
   fireEvent.mouseOver(checkbox);
   fireEvent.mouseMove(checkbox);
   fireEvent.mouseDown(checkbox);


### PR DESCRIPTION
BREAKING CHANGE: 🧨 clicking disabled checkbox no longer fires events

✅ Closes: #96